### PR TITLE
Removed /tmp dir usage

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,6 @@
 API_HOSTNAME = "127.0.0.1"
 API_PORT = 1470
 LOGS_DIR = "logs"
-JOBS_DIR = "grading_jobs"
 VERBOSE = True
 TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 SUCCESS_CODE = 200

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 API_HOSTNAME = "127.0.0.1"
 API_PORT = 1470
 LOGS_DIR = "logs"
+JOBS_DIR = "grading_jobs"
 VERBOSE = True
 TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 SUCCESS_CODE = 200

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
-import logging
 import asyncio
+import logging
 import os
 import signal
 import socket
@@ -7,7 +7,6 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from logging.handlers import TimedRotatingFileHandler
-from os import path
 
 import requests
 from chainlink import Chainlink
@@ -25,7 +24,6 @@ event_loop = asyncio.new_event_loop()
 
 # setting up logger
 os.makedirs(LOGS_DIR, exist_ok=True)
-os.makedirs(JOBS_DIR, exist_ok=True)
 logging.basicConfig(
     handlers=[
         TimedRotatingFileHandler('{}/log'.format(LOGS_DIR), when='midnight', backupCount=7),
@@ -74,7 +72,7 @@ def worker_routine():
 
         # execute job
         try:
-            chain = Chainlink(job[api_key.STAGES], workdir=path.join(os.getcwd(), JOBS_DIR))
+            chain = Chainlink(job[api_key.STAGES], workdir=os.getcwd())
             job_results = chain.run({})
         except Exception as ex:
             logger.critical("Grading job failed with exception:\n{}", ex)

--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from logging.handlers import TimedRotatingFileHandler
+from os import path
 
 import requests
 from chainlink import Chainlink
@@ -24,6 +25,7 @@ event_loop = asyncio.new_event_loop()
 
 # setting up logger
 os.makedirs(LOGS_DIR, exist_ok=True)
+os.makedirs(JOBS_DIR, exist_ok=True)
 logging.basicConfig(
     handlers=[
         TimedRotatingFileHandler('{}/log'.format(LOGS_DIR), when='midnight', backupCount=7),
@@ -72,7 +74,7 @@ def worker_routine():
 
         # execute job
         try:
-            chain = Chainlink(job[api_key.STAGES])
+            chain = Chainlink(job[api_key.STAGES], workdir=path.join(os.getcwd(), JOBS_DIR))
             job_results = chain.run({})
         except Exception as ex:
             logger.critical("Grading job failed with exception:\n{}", ex)


### PR DESCRIPTION
We will use the `cwd/jobs_dir` instead of `/tmp` for creating temp dirs. Resolves #13 